### PR TITLE
Authentication by api key.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -12,6 +12,7 @@ begin
     gem.authors = ["Eric Davis"]
     gem.add_dependency "activeresource", "~> 2.3.0"
     gem.add_development_dependency "thoughtbot-shoulda", ">= 0"
+    gem.add_development_dependency "webmock", ">= 0"
     # gem is a Gem::Specification... see http://www.rubygems.org/read/chapter/20 for additional settings
   end
   Jeweler::GemcutterTasks.new

--- a/lib/redmine_client/base.rb
+++ b/lib/redmine_client/base.rb
@@ -1,10 +1,20 @@
 module RedmineClient
   class Base < ActiveResource::Base
   
-    def self.configure(&block)
-      instance_eval &block
-    end
+    class << self
+      def configure(&block)
+        instance_eval &block
+      end
 
+      # Get your API key at "My account" page
+      def token= val
+        if val
+          (descendants + [self]).each do |resource|
+            resource.headers['X-Redmine-API-Key'] = val
+          end
+        end
+      end
+    end
   end
 end
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,6 +1,7 @@
 require 'rubygems'
 require 'test/unit'
 require 'shoulda'
+require 'webmock/test_unit'
 
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 $LOAD_PATH.unshift(File.dirname(__FILE__))

--- a/test/test_redmine_client.rb
+++ b/test/test_redmine_client.rb
@@ -1,7 +1,17 @@
 require 'helper'
 
 class TestRedmineClient < Test::Unit::TestCase
-  should "probably rename this file and start testing for real" do
-    flunk "hey buddy, you should probably rename this file and start testing for real"
+  context "token authentication" do
+    should "request should include X-Redmine-API-Key header when token is set" do
+      token = "12345"
+      stub_request(:get, "http://redmine.org/issues.xml")
+      RedmineClient::Base.configure do
+        self.site = "http://redmine.org"
+        self.token = token
+      end
+      RedmineClient::Issue.find(:all)
+      assert_requested :get, "http://redmine.org/issues.xml",
+        :headers => {'X-Redmine-API-Key' => token}, :times => 1
+    end
   end
 end


### PR DESCRIPTION
Redmine uses X-Redmine-API-Key header for authentication since https://github.com/edavis10/redmine/commit/07fe46e
It would be very useful to have this authentication method in the client. The patch introduces a way to use api key with auth header.
