### PR TITLE
Liberating activeresource dependency.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -10,7 +10,7 @@ begin
     gem.email = "edavis@littlestreamsoftware.com"
     gem.homepage = "http://github.com/edavis10/redmine_client"
     gem.authors = ["Eric Davis"]
-    gem.add_dependency "activeresource", "~> 2.3.0"
+    gem.add_dependency "activeresource", ">= 2.3.0"
     gem.add_development_dependency "thoughtbot-shoulda", ">= 0"
     # gem is a Gem::Specification... see http://www.rubygems.org/read/chapter/20 for additional settings
   end


### PR DESCRIPTION
My little Rails 3 app wants Redmine integration. There is no way of using 2 versions of ActiveResource gem in the app, so liberating activeresource dependency seems to be good solution.
